### PR TITLE
Fixed the Final boss crash

### DIFF
--- a/Scripts/R8/BossCurtain.txt
+++ b/Scripts/R8/BossCurtain.txt
@@ -47,7 +47,7 @@ sub ObjectMain
 			Object[-2].Value5=Object.XPos
 			Object[-2].Value5+=8126464
 			Object[-3].Value4=4096
-			Object[-2].Value1=75
+			Object[-2].Value1=EggMobile_Function75
 			Object[-1].Value6=Stage.XBoundary2
 			Object.State++
 		endif

--- a/Scripts/R8/EggMobile.txt
+++ b/Scripts/R8/EggMobile.txt
@@ -685,43 +685,43 @@ endfunction
 function EggMobile_Function75
 	switch Object[+1].Value2
 	case 0
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=120
 		Object[+2].State=1
 		break
 	case 1
-		Object.State=54
+		Object.State=EggMobile_Function54
 		Object.Value6=-64
 		Object.Value1=90112
 		Object[+2].State=1
 		break
 	case 2
-		Object.State=53
+		Object.State=EggMobile_Function53
 		break
 	case 3
-		Object.State=58
+		Object.State=EggMobile_Function58
 		break
 	case 4
-		Object.State=56
+		Object.State=EggMobile_Function56
 		Object.Value2=40960
 		Object[+1].Value7=Object[+3].YPos
 		Object[+1].Value7+=2097152
 		Object[+2].State=0
 		break
 	case 5
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=20
 		break
 	case 6
 		if Player.XPos>Object.XPos
 			Object.Direction=FACING_LEFT
-			Object.State=60
+			Object.State=EggMobile_Function60
 			Object[+1].Value7=Object[+1].Value6
 			Object[+1].Value7+=6815744
 			Object.Value6=16
 		else
 			Object.Direction=FACING_RIGHT
-			Object.State=59
+			Object.State=EggMobile_Function59
 			Object[+1].Value7=Object[+1].Value6
 			Object[+1].Value7-=6815744
 			Object.Value6=-16
@@ -731,18 +731,18 @@ function EggMobile_Function75
 		Object[+2].AnimationTimer=0
 		break
 	case 7
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=60
 		Object.Value6=0
 		break
 	case 8
 		if Object.XPos<Object[+3].XPos
-			Object.State=60
+			Object.State=EggMobile_Function60
 			Object[+1].Value7=Object[+1].Value6
 			Object[+1].Value7+=6815744
 			Object.Value6=16
 		else
-			Object.State=59
+			Object.State=EggMobile_Function59
 			Object[+1].Value7=Object[+1].Value6
 			Object[+1].Value7-=6815744
 			Object.Value6=-16
@@ -750,50 +750,50 @@ function EggMobile_Function75
 		Object[+2].AnimationTimer=0
 		break
 	case 9
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=60
 		Object.Value6=0
 		Object[+2].Value7=0
 		Object[+2].AnimationTimer=0
 		break
 	case 10
-		Object.State=55
+		Object.State=EggMobile_Function55
 		Object.Value6=-64
 		Object[+1].Value7=Object[+3].YPos
 		Object[+1].Value7-=2359296
 		break
 	case 11
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=90
 		break
 	case 12
 		if Object.Direction==FACING_RIGHT
-			Object.State=53
+			Object.State=EggMobile_Function53
 		else
-			Object.State=54
+			Object.State=EggMobile_Function54
 		endif
 		break
 	case 13
 		if Object.Direction==FACING_RIGHT
-			Object.State=54
+			Object.State=EggMobile_Function54
 		else
-			Object.State=53
+			Object.State=EggMobile_Function53
 		endif
 		break
 	case 14
 		if Object.Direction==FACING_RIGHT
-			Object.State=57
+			Object.State=EggMobile_Function57
 		else
-			Object.State=58
+			Object.State=EggMobile_Function58
 		endif
 		break
 	case 15
-		Object.State=61
+		Object.State=EggMobile_Function61
 		Object[+2].Value0=0
 		Object[+2].State=1
 		break
 	case 16
-		Object.State=62
+		Object.State=EggMobile_Function62
 		Object[+2].Value2=0
 		Object[+2].Value3=Player.XPos
 		Object[+2].Value3>>=16
@@ -806,31 +806,31 @@ function EggMobile_Function75
 		Object[+2].State=1
 		break
 	case 17
-		Object.State=64
+		Object.State=EggMobile_Function64
 		Object[+2].State=1
 		break
 	case 18
 		CallFunction(EggMobile_Function65)
-		Object.State=66
+		Object.State=EggMobile_Function66
 		Object.Value6=-64
 		Object[+2].State=0
 		break
 	case 19
-		Object.State=67
+		Object.State=EggMobile_Function67
 		break
 	case 20
-		Object.State=68
+		Object.State=EggMobile_Function68
 		break
 	case 21
 		CallFunction(EggMobile_Function65)
-		Object.State=66
+		Object.State=EggMobile_Function66
 		Object.Value6=-64
 		break
 	case 22
-		Object.State=67
+		Object.State=EggMobile_Function67
 		break
 	case 23
-		Object.State=68
+		Object.State=EggMobile_Function68
 		break
 
 	endswitch
@@ -846,30 +846,30 @@ endfunction
 function EggMobile_Function76
 	switch Object[+1].Value2
 	case 0
-		Object.State=54
+		Object.State=EggMobile_Function54
 		Object.Value6=-80
 		Object.Value1=98304
 		Object[+2].State=1
 		break
 	case 1
-		Object.State=53
+		Object.State=EggMobile_Function53
 		break
 	case 2
-		Object.State=58
+		Object.State=EggMobile_Function58
 		break
 	case 3
 		if Player.XPos>Object.XPos
-			Object.State=53
+			Object.State=EggMobile_Function53
 			Object.Direction=FACING_LEFT
 		else
-			Object.State=54
+			Object.State=EggMobile_Function54
 			Object.Direction=FACING_RIGHT
 		endif
 		break
 	case 4
 		Object.Value3/=160
 		Object.Value3*=160
-		Object.State=56
+		Object.State=EggMobile_Function56
 		Object.Value2=49152
 		Object[+1].Value7=Object[+3].YPos
 		Object[+1].Value7+=2097152
@@ -894,17 +894,17 @@ function EggMobile_Function76
 		loop
 		break
 	case 5
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=20
 		break
 	case 6
 		if Object.XPos<Object[+3].XPos
-			Object.State=60
+			Object.State=EggMobile_Function60
 			Object[+1].Value7=Object[+3].XPos
 			Object[+1].Value7-=1310720
 			Object.Value6=16
 		else
-			Object.State=59
+			Object.State=EggMobile_Function59
 			Object[+1].Value7=Object[+3].XPos
 			Object[+1].Value7+=1310720
 			Object.Value6=-16
@@ -914,69 +914,69 @@ function EggMobile_Function76
 		Object[+2].AnimationTimer=0
 		break
 	case 7
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=60
 		Object.Value6=0
 		break
 	case 8
 		if Object.XPos<Object[+1].Value6
 			Object.Direction=FACING_LEFT
-			Object.State=59
+			Object.State=EggMobile_Function59
 			Object[+1].Value7=Object[+1].Value4
 			Object.Value6=-16
 		else
 			Object.Direction=FACING_RIGHT
-			Object.State=60
+			Object.State=EggMobile_Function60
 			Object[+1].Value7=Object[+1].Value5
 			Object.Value6=16
 		endif
 		Object[+2].AnimationTimer=0
 		break
 	case 9
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=60
 		Object.Value6=0
 		Object[+2].Value7=2
 		Object[+2].AnimationTimer=0
 		break
 	case 10
-		Object.State=55
+		Object.State=EggMobile_Function55
 		Object.Value6=-80
 		Object[+1].Value7=Object[+3].YPos
 		Object[+1].Value7-=2359296
 		break
 	case 11
-		Object.State=52
+		Object.State=EggMobile_Function52
 		Object[+2].Value1=90
 		break
 	case 12
 		if Object.Direction==FACING_RIGHT
-			Object.State=53
+			Object.State=EggMobile_Function53
 		else
-			Object.State=54
+			Object.State=EggMobile_Function54
 		endif
 		break
 	case 13
 		if Object.Direction==FACING_RIGHT
-			Object.State=54
+			Object.State=EggMobile_Function54
 		else
-			Object.State=53
+			Object.State=EggMobile_Function53
 		endif
 		break
 	case 14
 		if Object.Direction==FACING_RIGHT
-			Object.State=57
+			Object.State=EggMobile_Function57
 		else
-			Object.State=58
+			Object.State=EggMobile_Function58
 		endif
 		break
 	case 15
-		Object.State=61
+		Object.State=EggMobile_Function61
 		Object[+2].Value0=0
 		Object[+2].State=1
 		break
 	case 16
-		Object.State=62
+		Object.State=EggMobile_Function62
 		Object[+2].Value2=0
 		Object[+2].Value3=Player.XPos
 		Object[+2].Value3>>=16
@@ -989,31 +989,31 @@ function EggMobile_Function76
 		Object[+2].State=1
 		break
 	case 17
-		Object.State=64
+		Object.State=EggMobile_Function64
 		Object[+2].State=1
 		break
 	case 18
 		CallFunction(EggMobile_Function65)
-		Object.State=66
+		Object.State=EggMobile_Function66
 		Object.Value6=-64
 		Object[+2].State=0
 		break
 	case 19
-		Object.State=67
+		Object.State=EggMobile_Function67
 		break
 	case 20
-		Object.State=68
+		Object.State=EggMobile_Function68
 		break
 	case 21
 		CallFunction(EggMobile_Function65)
-		Object.State=66
+		Object.State=EggMobile_Function66
 		Object.Value6=-64
 		break
 	case 22
-		Object.State=67
+		Object.State=EggMobile_Function67
 		break
 	case 23
-		Object.State=68
+		Object.State=EggMobile_Function68
 		break
 
 	endswitch
@@ -1029,23 +1029,23 @@ endfunction
 function EggMobile_Function77
 	switch Object[+1].Value2
 	case 0
-		Object.State=54
+		Object.State=EggMobile_Function54
 		Object.Value6=-106
 		Object.Value1=106496
 		Object[+2].State=1
 		break
 	case 1
-		Object.State=53
+		Object.State=EggMobile_Function53
 		break
 	case 2
-		Object.State=58
+		Object.State=EggMobile_Function58
 		break
 	case 3
-		Object.State=61
+		Object.State=EggMobile_Function61
 		Object[+2].Value0=0
 		break
 	case 4
-		Object.State=62
+		Object.State=EggMobile_Function62
 		Object[+2].Value2=0
 		Object[+2].Value3=Player.XPos
 		Object[+2].Value3>>=16
@@ -1058,31 +1058,31 @@ function EggMobile_Function77
 		Object[+2].State=1
 		break
 	case 5
-		Object.State=64
+		Object.State=EggMobile_Function64
 		Object[+2].State=1
 		break
 	case 6
 		CallFunction(EggMobile_Function65)
-		Object.State=66
+		Object.State=EggMobile_Function66
 		Object.Value6=-64
 		Object[+2].State=0
 		break
 	case 7
-		Object.State=67
+		Object.State=EggMobile_Function67
 		break
 	case 8
-		Object.State=68
+		Object.State=EggMobile_Function68
 		break
 	case 9
 		CallFunction(EggMobile_Function65)
-		Object.State=66
+		Object.State=EggMobile_Function66
 		Object.Value6=-64
 		break
 	case 10
-		Object.State=67
+		Object.State=EggMobile_Function67
 		break
 	case 11
-		Object.State=68
+		Object.State=EggMobile_Function68
 		break
 
 	endswitch
@@ -1098,19 +1098,19 @@ endfunction
 function EggMobile_Function78
 	switch Object[+1].Value2
 	case 0
-		Object.State=54
+		Object.State=EggMobile_Function54
 		Object.Value6=-160
 		Object.Value1=106496
 		Object[+2].State=1
 		break
 	case 1
-		Object.State=53
+		Object.State=EggMobile_Function53
 		break
 	case 2
-		Object.State=58
+		Object.State=EggMobile_Function58
 		break
 	case 3
-		Object.State=61
+		Object.State=EggMobile_Function61
 		Object[+2].Value0=4
 		Object.Value3>>=6
 		Object.Value3<<=6
@@ -1119,7 +1119,7 @@ function EggMobile_Function78
 		Object[+1].Value7-=4456448
 		break
 	case 4
-		Object.State=63
+		Object.State=EggMobile_Function63
 		Object[+2].Value2=0
 		Object[-4].Type=TypeName[BlankObject]
 		Object[-3].Type=TypeName[BlankObject]
@@ -1129,90 +1129,90 @@ function EggMobile_Function78
 		Object.Value4=0
 		break
 	case 5
-		Object.State=64
+		Object.State=EggMobile_Function64
 		break
 	case 6
-		Object.State=54
+		Object.State=EggMobile_Function54
 		Object.Value6=-160
 		break
 	case 7
-		Object.State=53
+		Object.State=EggMobile_Function53
 		break
 	case 8
-		Object.State=58
+		Object.State=EggMobile_Function58
 		break
 	case 9
 		if Player.XPos>Object.XPos
-			Object.State=53
+			Object.State=EggMobile_Function53
 			Object.Direction=FACING_LEFT
 		else
-			Object.State=54
+			Object.State=EggMobile_Function54
 			Object.Direction=FACING_RIGHT
 		endif
 		break
 	case 10
-		Object.State=70
+		Object.State=EggMobile_Function70
 		break
 	case 11
-		Object.State=72
+		Object.State=EggMobile_Function72
 		Object[+2].State=0
 		break
 	case 12
 		if Object.Direction==FACING_RIGHT
-			Object.State=73
+			Object.State=EggMobile_Function73
 			Object[+1].Value7=Object.XPos
 			Object[+1].Value7-=2686976
 		else
-			Object.State=74
+			Object.State=EggMobile_Function74
 			Object[+1].Value7=Object.XPos
 			Object[+1].Value7+=2686976
 		endif
 		break
 	case 13
 		if Object.Direction==FACING_RIGHT
-			Object.State=73
+			Object.State=EggMobile_Function73
 			Object[+1].Value7-=5373952
 		else
-			Object.State=74
+			Object.State=EggMobile_Function74
 			Object[+1].Value7+=5373952
 		endif
 		break
 	case 14
 		if Object.Direction==FACING_RIGHT
-			Object.State=73
+			Object.State=EggMobile_Function73
 			Object[+1].Value7-=5373952
 		else
-			Object.State=74
+			Object.State=EggMobile_Function74
 			Object[+1].Value7+=5373952
 		endif
 		break
 	case 15
 		if Object.Direction==FACING_RIGHT
-			Object.State=74
+			Object.State=EggMobile_Function74
 		else
-			Object.State=73
+			Object.State=EggMobile_Function73
 		endif
 		break
 	case 16
 		if Object.Direction==FACING_RIGHT
-			Object.State=74
+			Object.State=EggMobile_Function74
 			Object[+1].Value7+=5373952
 		else
-			Object.State=73
+			Object.State=EggMobile_Function73
 			Object[+1].Value7-=5373952
 		endif
 		break
 	case 17
 		if Object.Direction==FACING_RIGHT
-			Object.State=74
+			Object.State=EggMobile_Function74
 			Object[+1].Value7+=5373952
 		else
-			Object.State=73
+			Object.State=EggMobile_Function73
 			Object[+1].Value7-=5373952
 		endif
 		break
 	case 18
-		Object.State=71
+		Object.State=EggMobile_Function71
 		break
 
 	endswitch
@@ -1604,9 +1604,9 @@ sub ObjectPlayerInteraction
 						Object.Animation=3
 						Object.Value0=0
 						if Object[24].PropertyValue==3
-							Object.State=79
+							Object.State=EggMobile_Function79
 						else
-							Object.State=79
+							Object.State=EggMobile_Function79
 						endif
 						Object[+3].State++
 						Object[+3].Alpha>>=1
@@ -1623,9 +1623,9 @@ sub ObjectPlayerInteraction
 						Object.Value7=120
 						Object[+1].Value2=0
 						Object[+1].Value3=1
-						Object.State=69
+						Object.State=EggMobile_Function69
 						Object.Value2=65536
-						Object[+1].Value1=78
+						Object[+1].Value1=EggMobile_Function78
 						Object.Value0=0
 						Object.Animation=1
 						Object[+2].Value7=4
@@ -1638,9 +1638,9 @@ sub ObjectPlayerInteraction
 						Object.Value7=120
 						Object[+1].Value2=0
 						Object[+1].Value3=1
-						Object.State=69
+						Object.State=EggMobile_Function69
 						Object.Value2=57344
-						Object[+1].Value1=77
+						Object[+1].Value1=EggMobile_Function77
 						Object.Value0=0
 						Object.Animation=1
 						Object[+2].Value7=3
@@ -1653,9 +1653,9 @@ sub ObjectPlayerInteraction
 						Object.Value7=120
 						Object[+1].Value2=0
 						Object[+1].Value3=1
-						Object.State=69
+						Object.State=EggMobile_Function69
 						Object.Value2=49152
-						Object[+1].Value1=76
+						Object[+1].Value1=EggMobile_Function76
 						Object.Value0=0
 						Object.Animation=1
 						Object[+2].Value7=2


### PR DESCRIPTION
Fixed the Final boss from crashing when adding a new function to PlayerObject.txt. What is going on is that the integer values being set here are actually the values of functions.  What happens is when you add a new function in the PlayerObject, the function values are incremented by one. So, in the EggMobile.txt script where Object.State=59 is no longer the value 59 but now 60. To fix this, all that was needed was to change the values to point to their function call instead (which in the end, becomes a value that is NOT hard coded, but assigned during compile time).
The BossCurtain.txt object has an initialize call into the EggMobile.txt object and needed to be changed as well.
NOTE: there are still other objects within the game that break when adding functions.