### PR TITLE
Fixed a couple of other script function errors

### DIFF
--- a/Scripts/Menu/OptionsMenu.txt
+++ b/Scripts/Menu/OptionsMenu.txt
@@ -915,7 +915,7 @@ sub ObjectDraw
 		TempValue0+=18
 		DrawSpriteScreenFX(TempValue0,FX_INK,TempValue1,105)
 		Object.Alpha=255
-		CallFunction(6) // OptionsMenuC_Function6
+		CallFunction(OptionsMenu_Function6)
 		break
 	case 13
 	case 14

--- a/Scripts/R6/MovingBlocks.txt
+++ b/Scripts/R6/MovingBlocks.txt
@@ -543,16 +543,16 @@ sub ObjectStartup
 			Object[ArrayPos0].Value7=Object[ArrayPos0].YPos
 			switch Object[ArrayPos0].PropertyValue
 			case 0
-				Object[ArrayPos0].Rotation=50
+				Object[ArrayPos0].Rotation=MovingBlocks_Function50
 				break
 			case 1
-				Object[ArrayPos0].Rotation=53
+				Object[ArrayPos0].Rotation=MovingBlocks_Function53
 				break
 			case 3
-				Object[ArrayPos0].Rotation=51
+				Object[ArrayPos0].Rotation=MovingBlocks_Function51
 				break
 			case 4
-				Object[ArrayPos0].Rotation=52
+				Object[ArrayPos0].Rotation=MovingBlocks_Function52
 				break
 
 			endswitch


### PR DESCRIPTION
Options Menu was calling the value of `6`.  The comment was oddly named implying that it should call `OptionsMenuC_Function6` but that doesn't seem to be the case. Calling `OptionsMenu_Function6 ` seems fine.
Moving Block is interesting. Rotation isn't actually used for... rotation. Its a function pointer basically. This seems to somehow fix the ice bug.