### PR TITLE
Fix Wacky Workbench 3C bouncy floor sfx

### DIFF
--- a/Scripts/R6/R6BossCSetup.txt
+++ b/Scripts/R6/R6BossCSetup.txt
@@ -72,6 +72,7 @@ sub ObjectPlayerInteraction
 				Player.Timer=0
 				Player.YVelocity=-1441792
 				Player.State=PlayerObject_HandleAir
+				PlayStageSfx(0,0)
 #platform: Use_Haptics
 				HapticEffect(60,0,0,0)
 #endplatform


### PR DESCRIPTION
This fixes the good future of Wacky Workbench Act 3 not playing the sound effect for bouncy floors. I have tested and confirmed this is a bug with the decompiled scripts and not the original game. Special thanks to PimpUigi for bringing this to my attention.