### PR TITLE
Prevent Special Stage 5 from crashing on Mobile SW

### DIFF
--- a/Scripts/Special/BGEffects_S5.txt
+++ b/Scripts/Special/BGEffects_S5.txt
@@ -118,7 +118,7 @@ sub ObjectDraw
 		TempValue3++
 		ArrayPos0--
 	loop
-#platform: Mobile
+#platform: HW_Rendering
 	DrawSpriteScreenFX(0,FX_SCALE,0,0)
 	DrawRect(296,0,256,128,0,0,0,255)
 #endplatform


### PR DESCRIPTION
Did this since all other stages do the same thing
This does not fix the background, since i don't know how does sonic CD actually handle it on Mobile