### PR TITLE
Fix R5 Title Card compile issue

### DIFF
--- a/Scripts/R5/DropRock.txt
+++ b/Scripts/R5/DropRock.txt
@@ -377,6 +377,19 @@ end sub
 // ========================
 
 sub RSDKDraw
+	if Editor.ShowGizmos == true
+		// Draw a downwards arrow to show that this Rock is of the falling variety
+		
+		TempValue0 = Object.YPos
+		TempValue0 += 3145728
+		
+		Editor.DrawingOverlay = true
+		
+		DrawArrow(Object.XPos, Object.YPos, Object.XPos, TempValue0, 255, 255, 255)
+		
+		Editor.DrawingOverlay = false
+	end if
+	
 	DrawSprite(0)
 end sub
 

--- a/Scripts/R5/FallPlatform.txt
+++ b/Scripts/R5/FallPlatform.txt
@@ -329,6 +329,19 @@ sub RSDKDraw
 	end if
 	
 	DrawSprite(Object.PropertyValue)
+	
+	if Editor.ShowGizmos == true
+		Editor.DrawingOverlay = true
+		
+		// Draw an arrow pointing down to show that this Platform is of the falling type
+		
+		TempValue0 = Object.YPos
+		TempValue0 += 3145728
+		
+		DrawArrow(Object.XPos, Object.YPos, Object.XPos, TempValue0, 255, 255, 255)
+		
+		Editor.DrawingOverlay = false
+	end if
 end sub
 
 

--- a/Scripts/R5/HPlatformLarge.txt
+++ b/Scripts/R5/HPlatformLarge.txt
@@ -349,52 +349,50 @@ end sub
 // ========================
 
 sub RSDKDraw
+	
+	TempValue2 = false
+	
 	switch Object.PropertyValue
+	case 2
+		TempValue2 = true
 	case 0
 	case 1
-		// Right-moving Platform
-		Sin(Object.PlatformX, Object.Angle)
-		Object.PlatformX *= 6144
-		Object.PlatformX += 3145728
-		Object.PlatformX += Object.XPos
-		Object.PlatformX &= 4294901760
-		DrawSpriteXY(0, Object.PlatformX, Object.YPos)
+		TempValue0 = 6144
+		TempValue1 = 3145728
 		break
-		
-	case 2
-		// Right-moving Conveyor Platform
-		Sin(Object.PlatformX, Object.Angle)
-		Object.PlatformX *= 6144
-		Object.PlatformX += 3145728
-		Object.PlatformX += Object.XPos
-		Object.PlatformX &= 4294901760
-		DrawSpriteXY(0, Object.PlatformX, Object.YPos)
-		DrawSpriteXY(1, Object.PlatformX, Object.YPos)
-		break
-		
+	
+	
+	case 5
+		TempValue2 = true
 	case 3
 	case 4
-		// Left-moving Platform
-		Sin(Object.PlatformX, Object.Angle)
-		Object.PlatformX *= -6144
-		Object.PlatformX -= 3145728
-		Object.PlatformX += Object.XPos
-		Object.PlatformX &= 4294901760
-		DrawSpriteXY(0, Object.PlatformX, Object.YPos)
-		break
-		
-	case 5
-		// Left-moving Conveyor Platform
-		Sin(Object.PlatformX, Object.Angle)
-		Object.PlatformX *= -6144
-		Object.PlatformX -= 3145728
-		Object.PlatformX += Object.XPos
-		Object.PlatformX &= 4294901760
-		DrawSpriteXY(0, Object.PlatformX, Object.YPos)
-		DrawSpriteXY(1, Object.PlatformX, Object.YPos)
+		TempValue0 = -6144
+		TempValue1 = -3145728
 		break
 		
 	end switch
+	
+	TempValue3 = Object.XPos
+	TempValue3 &= 4294901760
+	DrawSpriteXY(0, TempValue3, Object.YPos)
+	DrawSpriteXY(TempValue2, TempValue3, Object.YPos)
+	
+	if Editor.ShowGizmos == true
+		Editor.DrawingOverlay = true
+		
+		// Show the Platform's path
+		
+		Sin(TempValue4, 128)
+		TempValue4 *= TempValue0
+		TempValue4 += TempValue1
+		TempValue4 += Object.XPos
+		TempValue4 &= 4294901760
+		
+		DrawLine(TempValue3, Object.YPos, TempValue4, Object.YPos, 255, 255, 255)
+		
+		Editor.DrawingOverlay = false
+	end if
+	
 end sub
 
 

--- a/Scripts/R5/HPlatformSmall.txt
+++ b/Scripts/R5/HPlatformSmall.txt
@@ -337,6 +337,7 @@ end sub
 
 
 sub RSDKDraw
+	
 	TempValue2 = 0
 	switch Object.PropertyValue
 	case 2

--- a/Scripts/R5/RisePlatform.txt
+++ b/Scripts/R5/RisePlatform.txt
@@ -217,7 +217,7 @@ sub RSDKDraw
 		// Draw the Platform's destination
 		
 		TempValue0 = Object.YPos
-		TempValue0 -= 0x032A0000
+		TempValue0 -= 53084160
 		DrawArrow(Object.XPos, Object.YPos, Object.XPos, TempValue0, 255, 255, 255)
 		
 		Editor.DrawingOverlay = false

--- a/Scripts/R5/RisePlatform2.txt
+++ b/Scripts/R5/RisePlatform2.txt
@@ -20,7 +20,7 @@
 
 
 sub ObjectMain
-
+	
 	switch Object.State
 	case RISEPLATFORM2_AWAITPLAYER
 		// Waiting for the Player to step on it to Launch
@@ -167,6 +167,7 @@ end sub
 
 
 sub ObjectStartup
+	
 	LoadSpriteSheet("R5/Objects.gif")
 	
 	// Large Platform Frame
@@ -184,8 +185,10 @@ sub ObjectStartup
 			Object[ArrayPos0].Priority = 3
 			
 		end if
+		
 		ArrayPos0++
 	loop
+	
 end sub
 
 
@@ -195,6 +198,19 @@ end sub
 
 sub RSDKDraw
 	DrawSprite(0)
+	
+	if Editor.ShowGizmos == true
+		// Draw the Platform's destination
+		
+		TempValue0 = Object.YPos
+		TempValue0 -= 20971520
+		
+		Editor.DrawingOverlay = true
+		
+		DrawArrow(Object.XPos, Object.YPos, Object.XPos, TempValue0, 255, 255, 255)
+		
+		Editor.DrawingOverlay = false
+	end if
 end sub
 
 

--- a/Scripts/TitleCards/R5_TitleCard.txt
+++ b/Scripts/TitleCards/R5_TitleCard.txt
@@ -60,8 +60,8 @@ sub ObjectDraw
 			Player.Speed = 0
 		end if
 		
-		if Object.FadeA > 0
-			if Object.FadeA == 256
+		if Object.Timer > 0
+			if Object.Timer == 256
 				PlayMusic(0)
 				
 				if Warp.XPos > 0
@@ -88,9 +88,9 @@ sub ObjectDraw
 				Warp.Frame = 0
 			end if
 			
-			SetScreenFade(Object.FadeR, Object.FadeG, Object.FadeB, Object.FadeA)
+			SetScreenFade(Object.FadeR, Object.FadeG, Object.FadeB, Object.Timer)
 			
-			Object.FadeA -= 8
+			Object.Timer -= 8
 		else
 			Fade_Colour = 0
 			
@@ -101,7 +101,7 @@ sub ObjectDraw
 			if TempValue0 == true
 				// If the level's been entered by normal means, then carry on as normal
 				Object.State = TITLECARD_SLIDEIN
-				Object.FadeA = 0
+				Object.Timer = 0
 			else
 				// The Player's warping in so just start the Stage,
 				// no need to show the Title Card or anything
@@ -143,11 +143,11 @@ sub ObjectDraw
 		break
 		
 	case TITLECARD_DISPLAY
-		if Object.FadeA == 90
+		if Object.Timer == 90
 			Object.State = TITLECARD_SLIDEOUT
 		else
 			// Hold for a second and a half
-			Object.FadeA++
+			Object.Timer++
 		end if
 		break
 		
@@ -257,9 +257,9 @@ sub ObjectStartup
 	
 	if Warp.XPos > 0
 		// If the Player is warping in, have a shorter fade-in time
-		Object[20].FadeA = 256
+		Object[20].Timer = 256
 	else
-		Object[20].FadeA = 384
+		Object[20].Timer = 384
 	end if
 	
 	// Quarts Quadrant should indeed enforce a roof,


### PR DESCRIPTION
Seems I forgot to test my cleanup changes from yesterday and the Quartz Quadrant Title Card had an error in it, so this fixes that. I've also included a few other small Object Gizmos for stuff I had forgotten about previously as well.